### PR TITLE
fix: update .env file to add STATICS_PATH var again

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 REDIS_HOST=localhost
 REDIS_PORT=6379
 MOSAICS_API_URL=http://localhost:3000/tasks.json
+STATICS_PATH=statics
 S3_ENDPOINT=localhost:9000
 S3_ACCESS_KEY_ID=mosaic
 S3_SECRET_ACCESS_KEY=mosaic#123


### PR DESCRIPTION
Hi,

Recently i cloned this repo to run locally and understand how this work, today i see new changes and resolve to make pull the changes, when executed the `worker` app, got this error: 

![image_2024-01-12_15-43-40](https://github.com/mauricioabreu/mosaic-video/assets/34068867/9e32c84b-7920-4f8f-afe9-8a9c6f74d329).

To resolve this, it was necessary add a environment variable `STATICS_PATH` on .env file again.
