### PR TITLE
Feat/hls player

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 REDIS_HOST=localhost
 REDIS_PORT=6379
 MOSAICS_API_URL=http://localhost:3000/tasks.json
+STATICS_PATH=statics
 S3_ENDPOINT=localhost:9000
 S3_ACCESS_KEY_ID=mosaic
 S3_SECRET_ACCESS_KEY=mosaic#123

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The project has two main components:
 
 * Generate mosaic from multiple video inputs;
 * Audio support (first video input);
-* Available inputs: HLS.
+* Available inputs: HLS;
+* A simple HLS Player available in: http://localhost:8090/player.
 
 ## Roadmap
 

--- a/cmd/player.go
+++ b/cmd/player.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/joho/godotenv"
+	"github.com/mauricioabreu/mosaic-video/internal/config"
+	"github.com/mauricioabreu/mosaic-video/internal/player"
+	"github.com/mauricioabreu/mosaic-video/internal/storage"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+)
+
+func Player() *cobra.Command {
+	return &cobra.Command{
+		Use:   "player",
+		Short: "Start player to serve hls content",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := godotenv.Load(".env", ".penv"); err != nil {
+				log.Println("Could not load .env file")
+			}
+
+			app := fx.New(
+				config.Module,
+				storage.Module,
+				fx.Provide(
+					player.NewHlsPlaylistHandler,
+					player.NewHlsFragmentHandler,
+					player.NewHlsPlayerHandler,
+				),
+				fx.Invoke(player.Run),
+			)
+
+			app.Run()
+		},
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ func NewRootCmd() *cobra.Command {
 
 	rootCmd.AddCommand(Work())
 	rootCmd.AddCommand(Store())
+	rootCmd.AddCommand(Player())
 
 	return rootCmd
 }

--- a/internal/player/hls_fragment_handler.go
+++ b/internal/player/hls_fragment_handler.go
@@ -1,0 +1,39 @@
+package player
+
+import (
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mauricioabreu/mosaic-video/internal/storage/s3"
+)
+
+type HlsFragmentHandler struct {
+	s3Client *s3.Client
+}
+
+func NewHlsFragmentHandler(s3c *s3.Client) *HlsFragmentHandler {
+	return &HlsFragmentHandler{
+		s3Client: s3c,
+	}
+}
+
+func (hh *HlsFragmentHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	filename := vars["filename"]
+	hh.serveFragmentHTTPImpl(filename, w, req)
+}
+
+func (hh *HlsFragmentHandler) serveFragmentHTTPImpl(filename string, w http.ResponseWriter, req *http.Request) {
+	content, err := hh.s3Client.Get(filename)
+	if err != nil {
+		log.Printf("failure to get %s file from bucket, err: %v", filename, err)
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	if _, err := io.Copy(w, content); err != nil {
+		log.Printf("failure copy %s file to response, err: %v", filename, err)
+		w.WriteHeader(http.StatusBadRequest)
+	}
+}

--- a/internal/player/hls_player_handler.go
+++ b/internal/player/hls_player_handler.go
@@ -1,0 +1,35 @@
+package player
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+type HlsPlayerHandler struct{}
+
+func NewHlsPlayerHandler() *HlsPlayerHandler {
+	return &HlsPlayerHandler{}
+}
+
+func (hh *HlsPlayerHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	currentPath, err := os.Getwd()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	indexPath := fmt.Sprintf("%s/internal/player/html/index.html", currentPath)
+	file, err := os.Open(indexPath)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+	fileInfo, err := file.Stat()
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	http.ServeContent(w, req, fileInfo.Name(), fileInfo.ModTime(), file)
+	return
+}

--- a/internal/player/hls_playlist_handler.go
+++ b/internal/player/hls_playlist_handler.go
@@ -1,0 +1,39 @@
+package player
+
+import (
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mauricioabreu/mosaic-video/internal/storage/s3"
+)
+
+type HlsPlaylistHandler struct {
+	s3Client *s3.Client
+}
+
+func NewHlsPlaylistHandler(s3c *s3.Client) *HlsPlaylistHandler {
+	return &HlsPlaylistHandler{
+		s3Client: s3c,
+	}
+}
+
+func (hh *HlsPlaylistHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	filename := vars["filename"]
+	hh.servePlaylistHTTPImpl(filename, w, req)
+}
+
+func (hh *HlsPlaylistHandler) servePlaylistHTTPImpl(filename string, w http.ResponseWriter, req *http.Request) {
+	content, err := hh.s3Client.Get(filename)
+	if err != nil {
+		log.Printf("failure to get %s file from bucket, err: %v", filename, err)
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	if _, err := io.Copy(w, content); err != nil {
+		log.Printf("failure copy %s file to response, err: %v", filename, err)
+		w.WriteHeader(http.StatusBadRequest)
+	}
+}

--- a/internal/player/html/index.html
+++ b/internal/player/html/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<script src="//cdn.jsdelivr.net/npm/hls.js@latest"></script>
+	<style>
+		.container {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
+		}
+		.video {
+			width: 90vw;
+            height: 90vh;
+		}
+	</style>
+</head>
+<body>
+	<div class="container" id="videoContainer">
+		<video class="video" id="video" controls></video>
+	</div>
+
+	<script>
+        const video = document.getElementById('video');
+        const playlistUrl = 'http://localhost:8090/playlist/playlist.m3u8';
+
+        if (Hls.isSupported()) {
+            var hls = new Hls();
+            hls.on(Hls.Events.MEDIA_ATTACHED, function () {
+            console.log('video and hls.js are now bound together !');
+            });
+            hls.on(Hls.Events.MANIFEST_PARSED, function (event, data) {
+            console.log(
+                'manifest loaded, found ' + data.levels.length + ' quality level',
+            );
+            });
+            hls.loadSource(playlistUrl);
+            hls.attachMedia(video);
+        }
+    </script>
+</body>
+</html>

--- a/internal/player/module.go
+++ b/internal/player/module.go
@@ -1,0 +1,36 @@
+package player
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"go.uber.org/fx"
+)
+
+var Module = fx.Provide(
+	NewHlsPlaylistHandler,
+	NewHlsFragmentHandler,
+	NewHlsPlayerHandler,
+)
+
+func Run(
+	lifecycle fx.Lifecycle,
+	playlistHandler *HlsPlaylistHandler,
+	fragmentHandler *HlsFragmentHandler,
+	playerHandler *HlsPlayerHandler,
+) {
+	lifecycle.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			r := mux.NewRouter()
+			r.Handle("/playlist/{filename}", playlistHandler).Methods("GET")
+			r.Handle("/fragment/{filename}", fragmentHandler).Methods("GET")
+			r.Handle("/player", playerHandler).Methods("GET")
+			go http.ListenAndServe(":8090", r)
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			return nil
+		},
+	})
+}

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"bytes"
 	"context"
+	"io"
 	"path/filepath"
 
 	"github.com/mauricioabreu/mosaic-video/internal/config"
@@ -39,6 +40,19 @@ func (s3c *Client) Upload(filename string, data []byte) error {
 		minio.PutObjectOptions{ContentType: getMIMEType(filename)},
 	)
 	return err
+}
+
+func (s3c *Client) Get(filename string) (io.Reader, error) {
+	output, err := s3c.client.GetObject(
+		context.Background(),
+		s3c.bucketName,
+		filename,
+		minio.GetObjectOptions{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
 }
 
 func getMIMEType(path string) string {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -3,4 +3,5 @@ package storage
 type Storage interface {
 	CreateBucket(bucketName string) error
 	Upload(path string, data []byte) error
+	Get(path string) ([]byte, error)
 }

--- a/justfile
+++ b/justfile
@@ -12,3 +12,6 @@ worker:
 
 storage:
     go run main.go storage
+
+player:
+    go run main.go player


### PR DESCRIPTION
Hi,

I'm excited about this project, therefore i implemented a simple HLS player for can be possible to watch a livestream.

It's was necessary to create three news HTTP handlers to serve and get object method in storage: 

- The playlist.m3u8 and playlist-{timestamp}.ts files;
- The index.html for HLS player in HTML page file.
  - See this video example in how does HLS player works: [video](https://github.com/mauricioabreu/mosaic-video/assets/34068867/c975f694-b1c2-40d3-a572-3d15f96f5050).

 To make this simple for now, i didn't use nginx as a proxy + cache.

This player run in app `player` so you need run `just player` or `go run main.go player`, if success, player runs in: http://localhost:8090/player.

## For the future

In near future, i would like to change the HLS Player to fetch `.m3u8` manifest on special endpoint, in this endpoint should return a JSON struct containing a list of playlist.m3u8 based in mosaic name returned in API Url, in this way, we can show all mosaics in screens.

Like this:

```json
{
    "mosaics": [
        "http://localhost:8090/playlist/money.m3u8",
        "http://localhost:8090/playlist/news.m3u8",
        "http://localhost:8090/playlist/politicies.m3u8"
    ]
}
``` 

Best reguards.