### PR TITLE
Fix/normalize create bucket

### DIFF
--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -27,7 +27,18 @@ func NewClient(cfg *config.Config) (storage.Storage, error) {
 }
 
 func (s3c *Client) CreateBucket(bucketName string) error {
-	return s3c.client.MakeBucket(context.Background(), bucketName, minio.MakeBucketOptions{})
+	ctx := context.Background()
+
+	exists, err := s3c.client.BucketExists(ctx, bucketName)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return s3c.client.MakeBucket(context.Background(), bucketName, minio.MakeBucketOptions{})
+	}
+
+	return nil
 }
 
 func (s3c *Client) Upload(filename string, data []byte) error {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -19,7 +19,7 @@ func GenerateMosaic(m mosaic.Mosaic, cfg *config.Config, locker locking.Locker, 
 		return nil
 	}
 
-	if err := createDirIfNotExist(m, cfg, stg); err != nil {
+	if err := stg.CreateBucket(m.Name); err != nil {
 		return err
 	}
 
@@ -40,14 +40,6 @@ func GenerateMosaic(m mosaic.Mosaic, cfg *config.Config, locker locking.Locker, 
 	}
 
 	runningProcesses[m.Name] = true
-
-	return nil
-}
-
-func createDirIfNotExist(m mosaic.Mosaic, cfg *config.Config, stg storage.Storage) error {
-	if cfg.StorageType.IsLocal() {
-		return stg.CreateBucket(m.Name)
-	}
 
 	return nil
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -19,7 +19,7 @@ func GenerateMosaic(m mosaic.Mosaic, cfg *config.Config, locker locking.Locker, 
 		return nil
 	}
 
-	if err := stg.CreateBucket(m.Name); err != nil {
+	if err := createBucket(&m, cfg, stg); err != nil {
 		return err
 	}
 
@@ -42,4 +42,12 @@ func GenerateMosaic(m mosaic.Mosaic, cfg *config.Config, locker locking.Locker, 
 	runningProcesses[m.Name] = true
 
 	return nil
+}
+
+func createBucket(m *mosaic.Mosaic, cfg *config.Config, stg storage.Storage) error {
+	if cfg.StorageType.IsLocal() {
+		return stg.CreateBucket(m.Name)
+	}
+
+	return stg.CreateBucket(cfg.S3.BucketName)
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -27,10 +27,7 @@ func TestGenerateMosaicWhenLockingFails(t *testing.T) {
 	}
 	cfg := &config.Config{}
 	locker.EXPECT().Obtain(gomock.Any(), "mosaicvideo", gomock.Any()).Return(nil, errors.New("error obtaining lock"))
-
-	if cfg.StorageType.IsLocal() {
-		storage.EXPECT().CreateBucket(gomock.Any()).Return(nil)
-	}
+	storage.EXPECT().CreateBucket(gomock.Any()).Return(nil)
 
 	runningProcesses := make(map[string]bool)
 
@@ -76,10 +73,7 @@ func TestGenerateMosaicWhenExecutingCommandFails(t *testing.T) {
 	lock := mocks.NewMockLock(ctrl)
 	lock.EXPECT().Release(gomock.Any()).Return(nil)
 	locker.EXPECT().Obtain(gomock.Any(), "mosaicvideo", gomock.Any()).Return(lock, nil)
-
-	if cfg.StorageType.IsLocal() {
-		storage.EXPECT().CreateBucket(gomock.Any()).Return(nil)
-	}
+	storage.EXPECT().CreateBucket(gomock.Any()).Return(nil)
 
 	cmdExecutor := mocks.NewMockCommand(ctrl)
 	cmdExecutor.EXPECT().Execute("ffmpeg", gomock.Any()).Return(errors.New("error executing command"))
@@ -90,6 +84,48 @@ func TestGenerateMosaicWhenExecutingCommandFails(t *testing.T) {
 		cfg,
 		locker,
 		cmdExecutor,
+		runningProcesses,
+		storage,
+	)
+
+	assert.Error(t, err)
+}
+
+func TestGenerateMosaicWhenCreateBucketFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := &config.Config{}
+	storage := mocks.NewMockStorage(ctrl)
+	mosaic := mosaic.Mosaic{
+		Name: "mosaicvideo",
+		Medias: []mosaic.Media{
+			{
+				URL: "http://example.com/mosaicvideo_1.m3u8",
+				Position: mosaic.Position{
+					X: 84,
+					Y: 40,
+				},
+				Scale: "1170x660"},
+			{
+				URL: "http://example.com/mosaicvideo_2.m3u8",
+				Position: mosaic.Position{
+					X: 1260,
+					Y: 40,
+				},
+				Scale: "568x320",
+			},
+		},
+	}
+
+	storage.EXPECT().CreateBucket(gomock.Any()).Return(errors.New("no permissions to create directory"))
+	runningProcesses := make(map[string]bool)
+
+	err := worker.GenerateMosaic(
+		mosaic,
+		cfg,
+		nil,
+		nil,
 		runningProcesses,
 		storage,
 	)


### PR DESCRIPTION
Normalized creating bucket process for s3 and local, because in s3 we need create only one bucket and uses a prefixes to organize segments, on the other hand in file system, we need create all directories and sub directory specified in .env file and a unique directory for each mosaic so,  before create bucket, it's verified whether exists, in negative case, we creating the bucket otherwise, it's ignored.